### PR TITLE
Adjust heatmap display colours

### DIFF
--- a/frontend/src/app/components/DisplayMap.js
+++ b/frontend/src/app/components/DisplayMap.js
@@ -77,7 +77,7 @@ const DisplayMap = () => {
                 </button>
             </div>
             <div id="map">
-                <MapContainer center={[40.7283, -73.9942]} zoom={10}>
+                <MapContainer center={[40.76657321777155, -73.9831392189498]} zoom={13}>
                     <TileLayer {...tileLayer} />
                     {/*<Routing />*/}
                     {/*<Routing2/>*/}

--- a/frontend/src/app/components/HeatMap.js
+++ b/frontend/src/app/components/HeatMap.js
@@ -39,6 +39,8 @@ const Heatmap = () => {
                 lngField: "long",
                 // which field name in your data represents the data value - default "value"
                 valueField: "count",
+                // customises thresholds and colours in the heatmap gradient
+                gradient: {0.25 : "cyan", 0.5: "blue", 0.75: "indigo", 1: "black"},
             };
 
         const heatmapLayer = L.heatLayer(


### PR DESCRIPTION
- Changes coordinates to centre map to be more central in Manhattan and adjusts initial zoom to show only relevant areas.
- Adds custom colour gradient to heat map. 

